### PR TITLE
(fix) add default export

### DIFF
--- a/index.js
+++ b/index.js
@@ -175,3 +175,5 @@ export class SynapsClient {
         document.body.removeChild(this.iframe);
     }
 }
+
+export default SynapsClient;


### PR DESCRIPTION
- Fixes `Attempted import error: '@synaps-io/synaps-client-sdk-js' does not contain a default export (imported as 'SynapsClient').`